### PR TITLE
[Experiment] Use FormDataEvent in place of input value syncing

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -18,12 +18,11 @@
   <title>image-crop-element demo</title>
 </head>
 <body>
-  <image-crop src="../ams.jpg" class="wrapper">
-    <div data-loading-slot class="loading">loading</div>
-    <input type="text" data-image-crop-input="x" name="x" size="4" aria-label="x">
-    <input type="text" data-image-crop-input="y" name="y" size="4" aria-label="y">
-    <input type="text" data-image-crop-input="width" name="width" size="4" aria-label="width">
-    <input type="text" data-image-crop-input="height" name="height" size="4" aria-label="height">
-  </image-crop>
+  <form>
+    <image-crop src="../ams.jpg" class="wrapper">
+      <div data-loading-slot class="loading">loading</div>
+    </image-crop>
+    <button name="submitter" value="value">Submit</button>
+  </form>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -101,9 +101,8 @@ function fireChangeEvent(target, result) {
   for (const key in result) {
     const value = Math.round(result[key] * ratio)
     result[key] = value
-    const slottedInput = target.querySelector(`[data-image-crop-input='${key}']`)
-    if (slottedInput) slottedInput.value = value
   }
+  target.result = result
 
   target.dispatchEvent(new CustomEvent('image-crop-change', {bubbles: true, detail: result}))
 }
@@ -119,6 +118,7 @@ export class ImageCropElement extends HTMLElement {
   connectedCallback() {
     if (this.constructed) return
     this.constructed = true
+    this.result = {}
 
     this.appendChild(document.importNode(tmpl.content, true))
     this.image = this.querySelector('img')
@@ -128,6 +128,8 @@ export class ImageCropElement extends HTMLElement {
     this.addEventListener('mouseleave', stopUpdate)
     this.addEventListener('mouseup', stopUpdate)
     this.box.addEventListener('mousedown', startUpdate)
+    const form = this.closest('form')
+    if (form) form.addEventListener('formdata', this.setFormValues.bind(this))
 
     if (this.src) this.image.src = this.src
   }
@@ -157,6 +159,12 @@ export class ImageCropElement extends HTMLElement {
       this.setAttribute('loaded', '')
     } else {
       this.removeAttribute('loaded')
+    }
+  }
+
+  setFormValues(event) {
+    for (const key in this.result) {
+      event.formData.append(key, this.result[key])
     }
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -17,10 +17,6 @@ describe('image-crop', function() {
       document.body.innerHTML = `
         <image-crop src="http://github.com/github.png?size=123">
           <div data-loading-slot>loading</div>
-          <input type="text" data-image-crop-input="x" name="x" aria-label="x">
-          <input type="text" data-image-crop-input="y" name="y" aria-label="y">
-          <input type="text" data-image-crop-input="width" name="width" aria-label="width">
-          <input type="text" data-image-crop-input="height" name="height" aria-label="height">
         </image-crop>
       `
     })
@@ -30,13 +26,11 @@ describe('image-crop', function() {
     })
 
     it('fires a change event and updates input', function(done) {
+      const values = {x: 0, y: 0, width: 123, height: 123}
       const ce = document.querySelector('image-crop')
-      ce.addEventListener('image-crop-change', function() {
+      ce.addEventListener('image-crop-change', function(event) {
         assert(ce.hasAttribute('loaded'), 'has loaded attribute')
-        assert.equal(document.querySelector('[name=x]').value, '0')
-        assert.equal(document.querySelector('[name=y]').value, '0')
-        assert.equal(document.querySelector('[name=width]').value, '123')
-        assert.equal(document.querySelector('[name=height]').value, '123')
+        assert.deepEqual(event.detail, values)
         done()
       })
     })


### PR DESCRIPTION
**Breaking changes / not mergeable for now**. https://github.com/whatwg/html/pull/4239

Notes:

1. `name` is no longer customizable.
2. ~~`remoteForm` (intercepts form submission on `submit` event) **WILL NOT** catch these values as it's fired before `formdata` (Spec: [`FormDataEvent`](https://html.spec.whatwg.org/#the-formdataevent-interface), [form submission algorithm](https://html.spec.whatwg.org/#form-submission-algorithm)).~~
   - ~~Changes to `remoteForm` are required.~~
      -~~ Intercepts `submit` & cancel it,~~
      - ~~Fire `formdata` from `remoteForm` manually to get these values,~~
      - ~~Construct a request from there.~~
   - `FormDataEvent.formData` includes `submitter` value 🎉 .
3. Dependent on browser implementations. https://github.com/whatwg/html/pull/4239#issuecomment-452265920

_Test this in Chrome Canary with Experimental Web Platform features_ 🎏 .

cc @dgraham @josh 