### PR TITLE
Add TS window declaration for ImageCropElement

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,3 +2,9 @@ export default class ImageCropElement extends HTMLElement {
   src: string || null
   loaded: boolean
 }
+
+declare global {
+  interface Window {
+    ImageCropElement: typeof ImageCropElement
+  }
+}


### PR DESCRIPTION
The TypeScript definition is incomplete as it doesn't properly reflect the assignment to Window.

This PR adds the declaration of `ImageCropElement` to the global window object, as that mutation is happening within the code and so should be reflected in the types.

 Refs https://github.com/github/application-architecture/issues/58