### PR TITLE
fix(types): use correct type expression

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 export default class ImageCropElement extends HTMLElement {
-  src: string || null
+  src: string | null
   loaded: boolean
 }
 


### PR DESCRIPTION
There was a typo in the .d.ts file. It used `string || null` which is meant to be `string | null`