### PR TITLE
example: Use correct build file

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -14,8 +14,8 @@
   </style>
   <meta charset="utf-8">
   <link href="../src/index.css" rel="stylesheet">
-  <!-- <script type="module" src="../dist/index.js"></script> -->
-  <script type="module" src="https://unpkg.com/@github/image-crop-element@latest/dist/index.js"></script>
+  <!-- <script type="module" src="../dist/index.esm.js"></script> -->
+  <script type="module" src="https://unpkg.com/@github/image-crop-element@latest/dist/index.esm.js"></script>
   <title>image-crop-element demo</title>
 </head>
 <body>


### PR DESCRIPTION
`dist/index.js` does not exist, it's either `dist/index.usm.js` or `dist/index.esm.js`.

Live test: https://github.github.io/image-crop-element/examples/ -- returns 404 and doesn't work.