### PR TITLE
Fix visible edge of crop area on wider images

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -41,7 +41,7 @@ image-crop .crop-outline {
   bottom: 0;
   left: 0;
   right: 0;
-  outline: 600px solid rgba(0, 0, 0, .3);
+  outline: 4000px solid rgba(0, 0, 0, .3);
 }
 image-crop .handle { position: absolute; }
 image-crop .handle:before {


### PR DESCRIPTION
I picked 4000px here because that feels like a high enough value here that the component is unlikely to be used on a page where the crop area is larger than this.

Closes #35